### PR TITLE
add top-level Cargo.toml workspace configuration file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,24 @@
+[workspace]
+members = [
+    "advanced/button-interrupt",
+    "advanced/i2c-driver",
+    "advanced/i2c-sensor-reading",
+    "common/lib/esp32-s3-dkc02-bsc",
+    "common/lib/get-uuid",
+    "common/lib/icm42670p",
+    "common/lib/mqtt-messages",
+    "intro/hardware-check",
+    "intro/http-client",
+    "intro/http-server",
+    "intro/mqtt/exercise",
+    "intro/mqtt/host-client",
+]
+
+resolver = "2"
+
+[profile.release]
+opt-level = "s"
+
+[profile.dev]
+debug = true    # Symbols are nice and they don't increase the size on Flash
+opt-level = "z"

--- a/advanced/button-interrupt/Cargo.toml
+++ b/advanced/button-interrupt/Cargo.toml
@@ -6,23 +6,15 @@ authors = [
     "Tanks Transfeld <tanks.transfeld@ferrous-systems.com>",
 ]
 edition = "2021"
-resolver = "2"
-
-[profile.release]
-opt-level = "s"
-
-[profile.dev]
-debug = true    # Symbols are nice and they don't increase the size on Flash
-opt-level = "z"
 
 [features]
 default = ["native"]
 native = ["esp-idf-sys/native"]
 
 [dependencies]
-esp-idf-sys = { version = "=0.31.5", features = ["binstart"] }
+esp-idf-sys = { version = "=0.31.10", features = ["binstart"] }
 anyhow = "1"
-esp32-s3-dkc02-bsc = { path = "../../common/lib/esp32-c3-dkc02-bsc" }
+esp32-s3-dkc02-bsc = { path = "../../common/lib/esp32-s3-dkc02-bsc" }
 
 [build-dependencies]
 embuild = "0.28"

--- a/advanced/i2c-driver/Cargo.toml
+++ b/advanced/i2c-driver/Cargo.toml
@@ -1,23 +1,15 @@
 [package]
-name = "i2c-driver-exercise"
+name = "i2c-driver"
 version = "0.1.0"
 authors = ["Tanks Transfeld <tanks.transfeld@ferrous-systems.com>"]
 edition = "2021"
-resolver = "2"
-
-[profile.release]
-opt-level = "s"
-
-[profile.dev]
-debug = true # Symbols are nice and they don't increase the size on Flash
-opt-level = "z"
 
 [features]
 default = ["native"]
 native = ["esp-idf-sys/native"]
 
 [dependencies]
-esp-idf-sys = { version = "=0.31.5", features = ["binstart"] }
+esp-idf-sys = { version = "=0.31.10", features = ["binstart"] }
 esp-idf-hal = "=0.38"
 anyhow = "1"
 embedded-hal = "0.2.7"

--- a/advanced/i2c-driver/src/main.rs
+++ b/advanced/i2c-driver/src/main.rs
@@ -9,11 +9,10 @@ use esp_idf_hal::{
 use esp_idf_sys::*;
 
 // uncomment the following line to run the solution, check lib.rs for further instructions
-// use i2c_driver_exercise::icm42670p_solution::{DeviceAddr, ICM42670P};
+// use i2c_driver::icm42670p_solution::{DeviceAddr, ICM42670P};
 
 // comment out the following line to run the exercise, check lib.rs for further instructions
-use i2c_driver_exercise::icm42670p::{DeviceAddr, ICM42670P};
-
+use i2c_driver::icm42670p::{DeviceAddr, ICM42670P};
 
 // Dont change this file. Work in the icm42670p.rs and modify it so main.rs runs.
 

--- a/advanced/i2c-sensor-reading/Cargo.toml
+++ b/advanced/i2c-sensor-reading/Cargo.toml
@@ -1,23 +1,15 @@
 [package]
-name = "i2c-sensor-exercise"
+name = "i2c-sensor-reading"
 version = "0.1.0"
 authors = ["Tanks Transfeld <tanks.transfeld@ferrous-systems.com>"]
 edition = "2021"
-resolver = "2"
-
-[profile.release]
-opt-level = "s"
-
-[profile.dev]
-debug = true # Symbols are nice and they don't increase the size on Flash
-opt-level = "z"
 
 [features]
 default = ["native"]
 native = ["esp-idf-sys/native"]
 
 [dependencies]
-esp-idf-sys = { version = "=0.31.5", features = ["binstart"] }
+esp-idf-sys = { version = "=0.31.10", features = ["binstart"] }
 esp-idf-hal = "=0.38"
 anyhow = "1"
 embedded-hal = "0.2.7"

--- a/intro/hardware-check/Cargo.toml
+++ b/intro/hardware-check/Cargo.toml
@@ -3,14 +3,6 @@ name = "hardware-check"
 version = "0.1.0"
 authors = ["Anatol Ulrich <anatol.ulrich@ferrous-systems.com>"]
 edition = "2021"
-resolver = "2"
-
-[profile.release]
-opt-level = "s"
-
-[profile.dev]
-debug = true    # Symbols are nice and they don't increase the size on Flash
-opt-level = "z"
 
 [features]
 default = ["native"]

--- a/intro/http-client/Cargo.toml
+++ b/intro/http-client/Cargo.toml
@@ -3,14 +3,6 @@ name = "http-client"
 version = "0.1.0"
 authors = ["Anatol Ulrich <anatol.ulrich@ferrous-systems.com>"]
 edition = "2018"
-resolver = "2"
-
-[profile.release]
-opt-level = "s"
-
-[profile.dev]
-debug = true    # Symbols are nice and they don't increase the size on Flash
-opt-level = "z"
 
 [features]
 default = ["native"]

--- a/intro/http-server/Cargo.toml
+++ b/intro/http-server/Cargo.toml
@@ -3,14 +3,6 @@ name = "http-server"
 version = "0.1.0"
 authors = ["Anatol Ulrich <anatol.ulrich@ferrous-systems.com>"]
 edition = "2018"
-resolver = "2"
-
-[profile.release]
-opt-level = "s"
-
-[profile.dev]
-debug = true    # Symbols are nice and they don't increase the size on Flash
-opt-level = "z"
 
 [features]
 default = ["native"]

--- a/intro/mqtt/exercise/Cargo.toml
+++ b/intro/mqtt/exercise/Cargo.toml
@@ -1,24 +1,16 @@
 [package]
-name = "mqtt"
+name = "exercise"
 version = "0.1.0"
 authors = ["Anatol Ulrich <anatol.ulrich@ferrous-systems.com>"]
 edition = "2018"
-resolver = "2"
-
-[profile.release]
-opt-level = "s"
-
-[profile.dev]
-debug = true    # Symbols are nice and they don't increase the size on Flash
-opt-level = "z"
 
 [features]
 default = ["native"]
 native = ["esp-idf-sys/native"]
 
 [dependencies]
-esp-idf-sys = { version = "=0.31.5", features = ["binstart"] }
-esp-idf-svc = { version = "=0.42.1", features = ["experimental", "alloc"] }
+esp-idf-sys = { version = "=0.31.10", features = ["binstart"] }
+esp-idf-svc = { version = "=0.42.5", features = ["experimental", "alloc"] }
 embedded-svc = "=0.22"
 esp32-s3-dkc02-bsc = { path = "../../../common/lib/esp32-s3-dkc02-bsc" }
 log = "0.4"

--- a/intro/mqtt/exercise/src/main.rs
+++ b/intro/mqtt/exercise/src/main.rs
@@ -1,6 +1,6 @@
 use bsc::{
     led::{RGB8, WS2812RMT},
-    temp_sensor::BoardTempSensor,
+    // temp_sensor::BoardTempSensor,
     wifi::wifi,
 };
 use embedded_svc::mqtt::client::{
@@ -49,7 +49,7 @@ fn main() -> anyhow::Result<()> {
     info!("our UUID is:");
     info!("{}", UUID);
 
-    let mut temp_sensor = BoardTempSensor::new_taking_peripherals();
+    // let mut temp_sensor = BoardTempSensor::new_taking_peripherals();
 
     let mut led = WS2812RMT::new()?;
     led.set_pixel(RGB8::new(1, 1, 0))?;
@@ -77,7 +77,7 @@ fn main() -> anyhow::Result<()> {
 
     loop {
         sleep(Duration::from_secs(1));
-        let temp = temp_sensor.read_owning_peripherals();
+        // let temp = temp_sensor.read_owning_peripherals();
 
         // 3. publish CPU temperature
         // client.publish( ... )?;


### PR DESCRIPTION
This also moves common configuration from each package's Cargo.toml file to the workspace file. And it makes minor adjustments to the names of the packages for consistency with the names of their directories. Finally, it comments out some calls to the sensor API that was commented out in a previous commit on this branch.

These changes would be helpful for some developers with existing tooling to install the Espressif Rust/LLVM toolchains and build projects with them.

In my case, I have some custom tooling that installs the toolchains (using 
install-rust-toolchain.sh from https://github.com/esp-rs/rust-build) and then automatically configures the environment for a `cargo build` invocation, such that it isn't necessary to first source a shell script in a terminal window before building there.

One of the requirements of the custom tooling is that there's a top-level workspace Cargo.toml file and that the names of the packages in the repo match the names of the directories containing them. That's a limitation of my tooling, not a requirement for building Rust packages generally! So perhaps I should address it in my tooling rather than in this repo.

However, I thought I'd submit this for your consideration, as it might be more generally useful for applying a consistent configuration to all the packages in the repo.
